### PR TITLE
Update adapt-simple-branchingBlockModel.js

### DIFF
--- a/js/adapt-simple-branchingBlockModel.js
+++ b/js/adapt-simple-branchingBlockModel.js
@@ -129,7 +129,7 @@ define([
          */
         getCorrectModel: function () {
             if (!this.isUsingCorrect()) return;
-            var config = this.getConfig();
+            var config = this.getConfig(),
             ids = config.correct;
 
             return this._getModels(ids);


### PR DESCRIPTION
Replaces ; with , to prevent 'ids' variable to be a global.